### PR TITLE
Use docker-entrypoint to inject environment variables 

### DIFF
--- a/chevalier/chevalier.gcfg
+++ b/chevalier/chevalier.gcfg
@@ -15,7 +15,7 @@ retryseconds = 10
 
 [vaultaire]
 # Endpoint for a contents read.
-contentsendpoint = tcp://chateau-XX.local:5580
+contentsendpoint = "tcp://chateau-XX.local:5580"
 # Origins to request from Vaultaire. 
 origins = PONIES
 

--- a/chevalier/docker-entrypoint.sh
+++ b/chevalier/docker-entrypoint.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
 set -e
 
+CONFIG_FILE=/etc/chevalier.gcfg
+
+
+# Replace KEY with VALUE in FILE
+function set_config() {
+	sed -i "s/\($1 *= *\).*/\1$2/" $3
+}
+
+if [ -z "$ES_HOST" ]; then
+	echo >&2 "error: missing ES_HOST environment variable. Defaulting to the value in $CONFIG_FILE"
+else
+	set_config "host" $ES_HOST /etc/chevalier.gcfg
+fi
+
+if [ -z "$BROKER_HOST" ]; then
+	echo >&2 "error: missing BROKER_HOST environment variable. Defaulting to the value in $CONFIG_FILE"
+else
+	BROKER_TCP="tcp:\/\/$BROKER_HOST:5580"
+	set_config "contentsendpoint" $BROKER_TCP /etc/chevalier.gcfg
+fi
+
+cat /etc/chevalier.gcfg
+
 chevalierd -read

--- a/chevalier/docker-entrypoint.sh
+++ b/chevalier/docker-entrypoint.sh
@@ -15,11 +15,11 @@ else
 	set_config "host" $ES_HOST /etc/chevalier.gcfg
 fi
 
-if [ -z "$BROKER_HOST" ]; then
-	echo >&2 "error: missing BROKER_HOST environment variable. Defaulting to the value in $CONFIG_FILE"
+if [ -z "$CONTENTS_HOST" ]; then
+	echo >&2 "error: missing CONTENTS_HOST environment variable. Defaulting to the value in $CONFIG_FILE"
 else
-	BROKER_TCP="tcp:\/\/$BROKER_HOST:5580"
-	set_config "contentsendpoint" $BROKER_TCP /etc/chevalier.gcfg
+	CONTENTS_TCP="tcp:\/\/$CONTENTS_HOST:5580"
+	set_config "contentsendpoint" $CONTENTS_TCP /etc/chevalier.gcfg
 fi
 
 cat /etc/chevalier.gcfg


### PR DESCRIPTION
Allows for chevalier image to be able to be run in multiple environments, by allowing run-time config options

Sample invocation:

```
docker run -e ES_HOST=localhost -e CONTENTS_HOST=chateau.local --name chevalier anchor/chevalier
```
